### PR TITLE
FEAT: Ajout du Artifact Registry pour stocker les images dockers du Projet

### DIFF
--- a/terraform/modules/artifact_registry/main.tf
+++ b/terraform/modules/artifact_registry/main.tf
@@ -1,0 +1,16 @@
+resource "google_artifact_registry_repository" "main" {
+  provider      = google
+  location      = var.region
+  repository_id = var.repository_id
+  format        = var.format
+  description   = var.description
+  project       = var.project_id
+}
+
+resource "google_artifact_registry_repository_iam_member" "writer" {
+  repository = google_artifact_registry_repository.main.name
+  location   = var.region
+  project    = var.project_id
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:${var.cloud_build_sa}"
+}

--- a/terraform/modules/artifact_registry/outputs.tf
+++ b/terraform/modules/artifact_registry/outputs.tf
@@ -1,0 +1,10 @@
+output "repository_name" {
+  description = "Nom du registre Artifact Registry"
+  value       = google_artifact_registry_repository.main.name
+}
+
+output "repository_url" {
+  description = "URL du registre Docker"
+  value       = "europe-west1-docker.pkg.dev/${var.project_id}/${var.repository_id}"
+}
+

--- a/terraform/modules/artifact_registry/provider.tf
+++ b/terraform/modules/artifact_registry/provider.tf
@@ -1,0 +1,5 @@
+provider "google" {
+  project     = "twittix"
+  region      = "europe-west1"
+  zone        = "europe-west1-b"
+}

--- a/terraform/modules/artifact_registry/variables.tf
+++ b/terraform/modules/artifact_registry/variables.tf
@@ -1,0 +1,31 @@
+variable "project_id" {
+  description = "ID du projet GCP"
+  type        = string
+}
+
+variable "region" {
+  description = "Région du registre (ex: europe-west1)"
+  type        = string
+}
+
+variable "repository_id" {
+  description = "Nom du dépôt Artifact Registry"
+  type        = string
+}
+
+variable "format" {
+  description = "Format du registre (DOCKER, MAVEN, NPM, etc.)"
+  type        = string
+  default     = "DOCKER"
+}
+
+variable "description" {
+  description = "Description du dépôt"
+  type        = string
+  default     = ""
+}
+
+variable "cloud_build_sa" {
+  description = "Adresse e-mail du service account Cloud Build à qui accorder les droits d'écriture"
+  type        = string
+}


### PR DESCRIPTION
# Ajout du module Terraform artifact_registry

## 🔧 Fonctionnalités ajoutées :
•	Création d’un dépôt Artifact Registry de type DOCKER dans GCP.
•	Permet de centraliser toutes les images conteneurisées de l’application Twittix.
•	Ajout d’un rôle IAM (roles/artifactregistry.writer) pour permettre à Cloud Build (ou autre service account) de pousser 
        des images Docker dans ce registre.

## Ce que fait le module :
•	Crée un dépôt Artifact Registry dans la région spécifiée (europe-west1, par défaut).

## Accepte les variables suivantes :
•	project_id
•	region
•	repository_id
•	format (par défaut : DOCKER)
•	description
•	cloud_build_sa (service account autorisé à push)

## Le rendre fonctionnel

Intégrer ce dépôt dans la CI/CD (Cloud Build ) pour y pousser automatiquement les images à chaque commit.
